### PR TITLE
SM64: Updating logic for move rando

### DIFF
--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -189,9 +189,8 @@ def create_regions(world: MultiWorld, options: SM64Options, player: int):
         create_locs(regSL, "SL: 100 Coins")
 
     regWDW = create_region("Wet-Dry World", player, world)
-    create_locs(regWDW, "WDW: Express Elevator--Hurry Up!")
-    wdw_top = create_subregion(regWDW, "WDW: Top", "WDW: Shocking Arrow Lifts!", "WDW: Top o' the Town",
-                                                   "WDW: Secrets in the Shallows & Sky", "WDW: Bob-omb Buddy")
+    create_locs(regWDW, "WDW: Express Elevator--Hurry Up!", "WDW: Shocking Arrow Lifts!")
+    wdw_top = create_subregion(regWDW, "WDW: Top", "WDW: Top o' the Town", "WDW: Secrets in the Shallows & Sky", "WDW: Bob-omb Buddy")
     wdw_downtown = create_subregion(regWDW, "WDW: Downtown", "WDW: Go to Town for Red Coins", "WDW: Quick Race Through Downtown!", "WDW: 1Up Block in Downtown")
     regWDW.subregions = [wdw_top, wdw_downtown]
     if options.enable_coin_stars:

--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -221,8 +221,8 @@ def create_regions(world: MultiWorld, options: SM64Options, player: int):
 
     regTTC = create_region("Tick Tock Clock", player, world)
     create_locs(regTTC, "TTC: Stop Time for Red Coins")
-    ttc_lower = create_subregion(regTTC, "TTC: Lower", "TTC: Roll into the Cage", "TTC: Get a Hand", "TTC: 1Up Block Midway Up")
-    ttc_upper = create_subregion(ttc_lower, "TTC: Upper", "TTC: Timed Jumps on Moving Bars", "TTC: The Pit and the Pendulums")
+    ttc_lower = create_subregion(regTTC, "TTC: Lower", "TTC: Roll into the Cage", "TTC: Get a Hand")
+    ttc_upper = create_subregion(ttc_lower, "TTC: Upper", "TTC: Timed Jumps on Moving Bars", "TTC: The Pit and the Pendulums", "TTC: 1Up Block Midway Up")
     ttc_top = create_subregion(ttc_upper, "TTC: Top", "TTC: Stomp on the Thwomp", "TTC: 1Up Block at the Top")
     regTTC.subregions = [ttc_lower, ttc_upper, ttc_top]
     if options.enable_coin_stars:

--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -155,10 +155,10 @@ def create_regions(world: MultiWorld, options: SM64Options, player: int):
 
     regSSL = create_region("Shifting Sand Land", player, world)
     create_locs(regSSL, "SSL: In the Talons of the Big Bird", "SSL: Shining Atop the Pyramid",
-                        "SSL: Free Flying for 8 Red Coins", "SSL: Bob-omb Buddy",
+                        "SSL: Free Flying for 8 Red Coins", "SSL: Stand Tall on the Four Pillars", "SSL: Bob-omb Buddy",
                         "SSL: 1Up Block Outside Pyramid", "SSL: 1Up Block Pyramid Left Path", "SSL: 1Up Block Pyramid Back")
     ssl_upper_pyramid = create_subregion(regSSL, "SSL: Upper Pyramid", "SSL: Inside the Ancient Pyramid",
-                                         "SSL: Stand Tall on the Four Pillars", "SSL: Pyramid Puzzle")
+                                         "SSL: Pyramid Puzzle")
     regSSL.subregions = [ssl_upper_pyramid]
     if options.enable_coin_stars:
         create_locs(regSSL, "SSL: 100 Coins")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -133,7 +133,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     # Cool, Cool Mountain
     rf.assign_rule("CCM: Wall Kicks Will Work", "TJ/WK & CANN | CANNLESS & TJ/WK | MOVELESS")
     # Big Boo's Haunt
-    rf.assign_rule("BBH: Third Floor", "WK+LG | MOVELESS & WK")
+    rf.assign_rule("BBH: Third Floor", "WK")
     rf.assign_rule("BBH: Roof", "LJ | MOVELESS")
     rf.assign_rule("BBH: Seek the 8 Red Coins", "BF/WK/TJ/SF")
     rf.assign_rule("BBH: Eye to Eye in the Secret Room", "VC")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -160,10 +160,10 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("SL: In the Deep Freeze", "WK/SF/LG/BF/CANN/TJ")
     rf.assign_rule("SL: Into the Igloo", "VC & TJ/SF/BF/WK/LG | MOVELESS & VC")
     # Wet-Dry World
-    rf.assign_rule("WDW: Top", "WK/TJ/SF/BF | MOVELESS")
-    rf.assign_rule("WDW: Downtown", "NAR & LG & TJ/SF/BF | CANN | MOVELESS & TJ+DV")
+    rf.assign_rule("WDW: Top", "WK/TJ/SF/BF/LJ | MOVELESS")
+    rf.assign_rule("WDW: Downtown", "NAR & LG & TJ/SF/BF | CANN | MOVELESS & TJ/DV")
     rf.assign_rule("WDW: Go to Town for Red Coins", "WK | MOVELESS & TJ")
-    rf.assign_rule("WDW: Quick Race Through Downtown!", "VC & WK/BF | VC & TJ+LG | MOVELESS & VC & TJ")
+    rf.assign_rule("WDW: Quick Race Through Downtown!", "VC & WK/BF/SF | VC & TJ+LG | MOVELESS & VC & TJ")
     rf.assign_rule("WDW: Bob-omb Buddy", "TJ | SF+LG | NAR & BF/SF")
     # Tall, Tall Mountain
     rf.assign_rule("TTM: Top", "MOVELESS & TJ | LJ/DV & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -166,7 +166,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("WDW: Quick Race Through Downtown!", "VC & WK/BF/SF | VC & TJ+LG | MOVELESS & VC & TJ")
     rf.assign_rule("WDW: Bob-omb Buddy", "TJ | SF+LG | NAR & BF/SF")
     # Tall, Tall Mountain
-    rf.assign_rule("TTM: Top", "MOVELESS & TJ | LJ/DV & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV")
+    rf.assign_rule("TTM: Top", "MOVELESS & TJ | LJ/DV & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV/LG")
     rf.assign_rule("TTM: Blast to the Lonely Mushroom", "CANN | CANNLESS & LJ | MOVELESS & CANNLESS")
     # Tiny-Huge Island
     rf.assign_rule("THI: 1Up Block THI Small near Start", "NAR | {THI: Pipes}")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -139,7 +139,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("BBH: Eye to Eye in the Secret Room", "VC")
     # Haze Maze Cave
     rf.assign_rule("HMC: Red Coin Area", "CL & WK/LG/BF/SF/TJ | MOVELESS & WK")
-    rf.assign_rule("HMC: Pit Islands", "TJ+CL | MOVELESS & WK & TJ/LJ | MOVELESS & WK+SF+LG")
+    rf.assign_rule("HMC: A-Maze-Ing Emergency Exit", "TJ+CL | MOVELESS & WK & TJ/LJ | MOVELESS & WK+SF+LG | MOVELESS & TJ+DV | MOVELESS & WK/SF/BF & CL")
+    rf.assign_rule("HMC: 1Up Block above Pit", "TJ+CL | MOVELESS & WK & TJ/SF/LJ | MOVELESS & WK/SF/BF & CL")
     rf.assign_rule("HMC: Metal-Head Mario Can Move!", "LJ+MC | CAPLESS & LJ+TJ | CAPLESS & MOVELESS & LJ/TJ/WK/DV")
     rf.assign_rule("HMC: Navigating the Toxic Maze", "WK/SF/BF/TJ")
     rf.assign_rule("HMC: Watch for Rolling Rocks", "WK")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -140,7 +140,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     # Haze Maze Cave
     rf.assign_rule("HMC: Red Coin Area", "CL & WK/LG/BF/SF/TJ | MOVELESS & WK")
     rf.assign_rule("HMC: Pit Islands", "TJ+CL | MOVELESS & WK & TJ/LJ | MOVELESS & WK+SF+LG")
-    rf.assign_rule("HMC: Metal-Head Mario Can Move!", "LJ+MC | CAPLESS & LJ+TJ | CAPLESS & MOVELESS & LJ/TJ/WK")
+    rf.assign_rule("HMC: Metal-Head Mario Can Move!", "LJ+MC | CAPLESS & LJ+TJ | CAPLESS & MOVELESS & LJ/TJ/WK/DV")
     rf.assign_rule("HMC: Navigating the Toxic Maze", "WK/SF/BF/TJ")
     rf.assign_rule("HMC: Watch for Rolling Rocks", "WK")
     # Lethal Lava Land

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -167,7 +167,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("WDW: Quick Race Through Downtown!", "VC & WK/BF/SF | VC & TJ+LG | MOVELESS & VC & TJ")
     rf.assign_rule("WDW: Bob-omb Buddy", "TJ | SF+LG | NAR & BF/SF")
     # Tall, Tall Mountain
-    rf.assign_rule("TTM: Top", "MOVELESS & TJ | LJ/DV & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV/LG")
+    rf.assign_rule("TTM: Top", "TJ+DV | LJ/DV & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV/LG | MOVELESS & TJ")
     rf.assign_rule("TTM: Blast to the Lonely Mushroom", "CANN | CANNLESS & LJ | MOVELESS & CANNLESS")
     # Tiny-Huge Island
     rf.assign_rule("THI: 1Up Block THI Small near Start", "NAR | {THI: Pipes}")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -115,7 +115,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
 
     # Course Rules
     # Bob-omb Battlefield
-    rf.assign_rule("BoB: Island", "CANN | CANNLESS & WC & TJ | CAPLESS & CANNLESS & LJ")
+    rf.assign_rule("BoB: Shoot to the Island in the Sky", "CANN | WC & TJ | CAPLESS & CANNLESS & LJ")
+    rf.assign_rule("BoB: Find the 8 Red Coins", "CANN | WC & TJ | CANNLESS & CAPLESS & LJ & SF/BF/TJ/CL")
     rf.assign_rule("BoB: Mario Wings to the Sky",  "CANN & WC | CAPLESS & CANN")
     rf.assign_rule("BoB: Behind Chain Chomp's Gate", "GP | MOVELESS")
     # Whomp's Fortress

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -125,7 +125,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("WF: Fall onto the Caged Island", "CL & {WF: Tower} | MOVELESS & TJ | MOVELESS & LJ | MOVELESS & CANN")
     rf.assign_rule("WF: Blast Away the Wall", "CANN | CANNLESS & LG")
     # Jolly Roger Bay
-    rf.assign_rule("JRB: Upper", "TJ/BF/SF/WK | MOVELESS & LG")
+    rf.assign_rule("JRB: Upper", "TJ/BF/SF/WK/CANN | MOVELESS & LG")
     rf.assign_rule("JRB: Red Coins on the Ship Afloat", "CL/CANN/TJ | MOVELESS & BF/WK")
     rf.assign_rule("JRB: Blast to the Stone Pillar", "CANN+CL | CANNLESS & MOVELESS | CANN & MOVELESS")
     rf.assign_rule("JRB: Through the Jet Stream", "MC | CAPLESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -148,7 +148,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("LLL: Hot-Foot-It into the Volcano", "WK & MOVELESS")
     rf.assign_rule("LLL: Elevator Tour in the Volcano", "WK & LJ & MOVELESS")
     # Shifting Sand Land
-    rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG | MOVELESS")
+    rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG/WK | MOVELESS")
     rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")
     rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -172,7 +172,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("THI: 1Up Block THI Small near Start", "NAR | {THI: Pipes}")
     rf.assign_rule("THI: Pipes", "NAR | LJ/TJ/DV/LG | MOVELESS & BF/SF/KK")
     rf.assign_rule("THI: Large Top", "NAR | LJ/TJ/DV | MOVELESS")
-    rf.assign_rule("THI: Wiggler's Red Coins", "WK")
+    rf.assign_rule("THI: Wiggler's Red Coins", "WK | LJ+LG | CL & SF/TJ/LG | MOVELESS & TJ+DV")
     rf.assign_rule("THI: Make Wiggler Squirm", "GP | MOVELESS & DV")
     # Tick Tock Clock
     rf.assign_rule("TTC: Lower", "LG/TJ/SF/BF/WK")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -145,6 +145,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("HMC: Watch for Rolling Rocks", "WK")
     # Lethal Lava Land
     rf.assign_rule("LLL: Upper Volcano", "CL")
+    rf.assign_rule("LLL: Hot-Foot-It into the Volcano", "WK & MOVELESS")
+    rf.assign_rule("LLL: Elevator Tour in the Volcano", "WK & LJ & MOVELESS")
     # Shifting Sand Land
     rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG | MOVELESS")
     rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -161,7 +161,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("SL: In the Deep Freeze", "WK/SF/LG/BF/CANN/TJ | MOVELESS")
     rf.assign_rule("SL: Into the Igloo", "VC & TJ/SF/BF/WK/LG | MOVELESS & VC")
     # Wet-Dry World
-    rf.assign_rule("WDW: Top", "WK/TJ/SF/BF/LJ | MOVELESS")
+    rf.assign_rule("WDW: Top", "WK/TJ/SF/BF/LJ | CANN | MOVELESS")
     rf.assign_rule("WDW: Downtown", "NAR & LG & TJ/SF/BF | CANN | MOVELESS & TJ/DV")
     rf.assign_rule("WDW: Go to Town for Red Coins", "WK | MOVELESS & TJ")
     rf.assign_rule("WDW: Quick Race Through Downtown!", "VC & WK/BF/SF | VC & TJ+LG | MOVELESS & VC & TJ")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -158,7 +158,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("DDD: Collect the Caps...", "VC+MC | CAPLESS & VC")
     # Snowman's Land
     rf.assign_rule("SL: Snowman's Big Head", "BF/SF/CANN/TJ")
-    rf.assign_rule("SL: In the Deep Freeze", "WK/SF/LG/BF/CANN/TJ")
+    rf.assign_rule("SL: In the Deep Freeze", "WK/SF/LG/BF/CANN/TJ | MOVELESS")
     rf.assign_rule("SL: Into the Igloo", "VC & TJ/SF/BF/WK/LG | MOVELESS & VC")
     # Wet-Dry World
     rf.assign_rule("WDW: Top", "WK/TJ/SF/BF/LJ | MOVELESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -134,7 +134,6 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     # Big Boo's Haunt
     rf.assign_rule("BBH: Third Floor", "WK+LG | MOVELESS & WK")
     rf.assign_rule("BBH: Roof", "LJ | MOVELESS")
-    rf.assign_rule("BBH: Secret of the Haunted Books", "KK | MOVELESS")
     rf.assign_rule("BBH: Seek the 8 Red Coins", "BF/WK/TJ/SF")
     rf.assign_rule("BBH: Eye to Eye in the Secret Room", "VC")
     # Haze Maze Cave

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -108,9 +108,9 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
 
     connect_regions(world, player, "Second Floor", "Third Floor", lambda state: state.has("Power Star", player, star_costs["SecondFloorDoorCost"]))
 
-    connect_regions(world, player, "Third Floor", randomized_entrances_s["Tick Tock Clock"], rf.build_rule("LG/TJ/SF/BF/WK"))
-    connect_regions(world, player, "Third Floor", randomized_entrances_s["Rainbow Ride"], rf.build_rule("TJ/SF/BF"))
-    connect_regions(world, player, "Third Floor", randomized_entrances_s["Wing Mario over the Rainbow"], rf.build_rule("TJ/SF/BF"))
+    connect_regions(world, player, "Third Floor", randomized_entrances_s["Tick Tock Clock"], rf.build_rule("LG/TJ/SF/BF/MOVELESS & WK"))
+    connect_regions(world, player, "Third Floor", randomized_entrances_s["Rainbow Ride"], rf.build_rule("TJ/SF/BF/WK"))
+    connect_regions(world, player, "Third Floor", randomized_entrances_s["Wing Mario over the Rainbow"], rf.build_rule("TJ/SF/BF/WK"))
     connect_regions(world, player, "Third Floor", "Bowser in the Sky", lambda state: state.has("Power Star", player, star_costs["StarsToFinish"]))
 
     # Course Rules

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -196,8 +196,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("Vanish Cap Under the Moat Red Coins", "TJ/BF/SF/LG/WK & VC | CAPLESS & WK")
     # Bowser in the Fire Sea
     rf.assign_rule("BitFS: Upper", "CL | MOVELESS & TJ+WK")
-    rf.assign_rule("Bowser in the Fire Sea Red Coins", "LG/WK")
-    rf.assign_rule("Bowser in the Fire Sea 1Up Block Near Poles", "LG/WK")
+    rf.assign_rule("Bowser in the Fire Sea Red Coins", "LG/WK | MOVELESS")
+    rf.assign_rule("Bowser in the Fire Sea 1Up Block Near Poles", "LG/WK | MOVELESS")
     # Wing Mario Over the Rainbow
     rf.assign_rule("Wing Mario Over the Rainbow Red Coins", "TJ+WC")
     rf.assign_rule("Wing Mario Over the Rainbow 1Up Block", "TJ+WC")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -195,14 +195,14 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("Vanish Cap Under the Moat Switch", "WK/TJ/BF/SF/LG | MOVELESS")
     rf.assign_rule("Vanish Cap Under the Moat Red Coins", "TJ/BF/SF/LG/WK & VC | CAPLESS & WK")
     # Bowser in the Fire Sea
-    rf.assign_rule("BitFS: Upper", "CL")
+    rf.assign_rule("BitFS: Upper", "CL | MOVELESS & TJ+WK")
     rf.assign_rule("Bowser in the Fire Sea Red Coins", "LG/WK")
     rf.assign_rule("Bowser in the Fire Sea 1Up Block Near Poles", "LG/WK")
     # Wing Mario Over the Rainbow
     rf.assign_rule("Wing Mario Over the Rainbow Red Coins", "TJ+WC")
     rf.assign_rule("Wing Mario Over the Rainbow 1Up Block", "TJ+WC")
     # Bowser in the Sky
-    rf.assign_rule("BitS: Top", "CL+TJ | CL+SF+LG | MOVELESS & TJ+WK+LG")
+    rf.assign_rule("BitS: Top", "CL & TJ/SF/BF/LG | MOVELESS & TJ+WK")
     # 100 Coin Stars
     if options.enable_coin_stars:
         rf.assign_rule("BoB: 100 Coins", "CANN & WC | CANNLESS & WC & TJ")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -171,7 +171,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("TTM: Blast to the Lonely Mushroom", "CANN | CANNLESS & LJ | MOVELESS & CANNLESS")
     # Tiny-Huge Island
     rf.assign_rule("THI: 1Up Block THI Small near Start", "NAR | {THI: Pipes}")
-    rf.assign_rule("THI: Pipes", "NAR | LJ/TJ/DV/LG | MOVELESS & BF/SF/KK")
+    rf.assign_rule("THI: Pipes", "NAR | LJ/LG | TJ+DV | MOVELESS & TJ/DV | MOVELESS & BF/SF/KK")
     rf.assign_rule("THI: Large Top", "NAR | LJ/TJ/DV | MOVELESS")
     rf.assign_rule("THI: Wiggler's Red Coins", "WK | LJ+LG | CL & SF/TJ/LG | MOVELESS & TJ+DV")
     rf.assign_rule("THI: Make Wiggler Squirm", "GP | MOVELESS & DV")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -181,8 +181,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("TTC: Stomp on the Thwomp", "LG & TJ/SF/BF")
     rf.assign_rule("TTC: Stop Time for Red Coins", "NAR | {TTC: Lower}")
     # Rainbow Ride
-    rf.assign_rule("RR: Maze", "WK | LJ & SF/BF/TJ | MOVELESS & LG/TJ")
-    rf.assign_rule("RR: Bob-omb Buddy", "WK | MOVELESS & LG")
+    rf.assign_rule("RR: Maze", "WK | LJ & SF/BF/TJ | MOVELESS & LG/TJ/KK")
+    rf.assign_rule("RR: Bob-omb Buddy", "WK | MOVELESS & LG/KK")
     rf.assign_rule("RR: Swingin' in the Breeze", "LG/TJ/BF/SF | MOVELESS")
     rf.assign_rule("RR: Tricky Triangles!", "LG/TJ/BF/SF | MOVELESS")
     rf.assign_rule("RR: Cruiser", "WK/SF/BF/LG/TJ")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -152,7 +152,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")
     rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
-    rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")
+    rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}}")
     rf.assign_rule("DDD: Through the Jet Stream", "MC | CAPLESS")
     rf.assign_rule("DDD: Collect the Caps...", "VC+MC | CAPLESS & VC")
     # Snowman's Land

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -147,6 +147,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("LLL: Upper Volcano", "CL")
     # Shifting Sand Land
     rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG | MOVELESS")
+    rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")
     rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
     rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -126,7 +126,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("WF: Blast Away the Wall", "CANN | CANNLESS & LG")
     # Jolly Roger Bay
     rf.assign_rule("JRB: Upper", "TJ/BF/SF/WK | MOVELESS & LG")
-    rf.assign_rule("JRB: Red Coins on the Ship Afloat", "CL/CANN/TJ/BF/WK")
+    rf.assign_rule("JRB: Red Coins on the Ship Afloat", "CL/CANN/TJ | MOVELESS & BF/WK")
     rf.assign_rule("JRB: Blast to the Stone Pillar", "CANN+CL | CANNLESS & MOVELESS | CANN & MOVELESS")
     rf.assign_rule("JRB: Through the Jet Stream", "MC | CAPLESS")
     # Cool, Cool Mountain

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -181,8 +181,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     # Rainbow Ride
     rf.assign_rule("RR: Maze", "WK | LJ & SF/BF/TJ | MOVELESS & LG/TJ")
     rf.assign_rule("RR: Bob-omb Buddy", "WK | MOVELESS & LG")
-    rf.assign_rule("RR: Swingin' in the Breeze", "LG/TJ/BF/SF")
-    rf.assign_rule("RR: Tricky Triangles!", "LG/TJ/BF/SF")
+    rf.assign_rule("RR: Swingin' in the Breeze", "LG/TJ/BF/SF | MOVELESS")
+    rf.assign_rule("RR: Tricky Triangles!", "LG/TJ/BF/SF | MOVELESS")
     rf.assign_rule("RR: Cruiser", "WK/SF/BF/LG/TJ")
     rf.assign_rule("RR: House", "TJ/SF/BF/LG")
     rf.assign_rule("RR: Somewhere Over the Rainbow", "CANN")
@@ -247,6 +247,7 @@ class RuleFactory:
 
     token_table = {
         "TJ": "Triple Jump",
+        "DJ": "Triple Jump",
         "LJ": "Long Jump",
         "BF": "Backflip",
         "SF": "Side Flip",

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -147,7 +147,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("LLL: Upper Volcano", "CL")
     # Shifting Sand Land
     rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG | MOVELESS")
-    rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ/SF/BF & TJ+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
+    rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
     rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")
     rf.assign_rule("DDD: Through the Jet Stream", "MC | CAPLESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -158,7 +158,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("DDD: Collect the Caps...", "VC+MC | CAPLESS & VC")
     # Snowman's Land
     rf.assign_rule("SL: Snowman's Big Head", "BF/SF/CANN/TJ")
-    rf.assign_rule("SL: In the Deep Freeze", "WK/SF/LG/BF/CANN/TJ | MOVELESS")
+    rf.assign_rule("SL: In the Deep Freeze", "WK/SF/LG/BF/CANN | MOVELESS")
     rf.assign_rule("SL: Into the Igloo", "VC & TJ/SF/BF/WK/LG | MOVELESS & VC")
     # Wet-Dry World
     rf.assign_rule("WDW: Top", "WK/TJ/SF/BF/LJ | CANN | MOVELESS")
@@ -167,7 +167,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("WDW: Quick Race Through Downtown!", "VC & WK/BF/SF | VC & TJ+LG | MOVELESS & VC & TJ")
     rf.assign_rule("WDW: Bob-omb Buddy", "TJ | SF+LG | NAR & BF/SF")
     # Tall, Tall Mountain
-    rf.assign_rule("TTM: Top", "TJ+DV | LJ/DV & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV/LG | MOVELESS & TJ")
+    rf.assign_rule("TTM: Top", "TJ+DV | LJ & LG/KK | MOVELESS & WK & SF/LG | MOVELESS & KK/DV/LJ/TJ")
     rf.assign_rule("TTM: Blast to the Lonely Mushroom", "CANN | CANNLESS & LJ | MOVELESS & CANNLESS")
     # Tiny-Huge Island
     rf.assign_rule("THI: 1Up Block THI Small near Start", "NAR | {THI: Pipes}")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -139,8 +139,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("BBH: Eye to Eye in the Secret Room", "VC")
     # Haze Maze Cave
     rf.assign_rule("HMC: Red Coin Area", "CL & WK/LG/BF/SF/TJ | MOVELESS & WK")
-    rf.assign_rule("HMC: A-Maze-Ing Emergency Exit", "TJ+CL | MOVELESS & WK & TJ/LJ | MOVELESS & WK+SF+LG | MOVELESS & TJ+DV | MOVELESS & WK/SF/BF & CL")
-    rf.assign_rule("HMC: 1Up Block above Pit", "TJ+CL | MOVELESS & WK & TJ/SF/LJ | MOVELESS & WK/SF/BF & CL")
+    rf.assign_rule("HMC: A-Maze-Ing Emergency Exit", "TJ+CL | MOVELESS & WK & TJ | MOVELESS & TJ+DV | MOVELESS & WK/SF/BF/TJ & CL/LJ")
+    rf.assign_rule("HMC: 1Up Block above Pit", "TJ+CL | MOVELESS & WK TJ/SF/LG | MOVELESS & WK/SF/BF/TJ & CL/LJ")
     rf.assign_rule("HMC: Metal-Head Mario Can Move!", "LJ+MC | CAPLESS & LJ+TJ | CAPLESS & MOVELESS & LJ/TJ/WK/DV")
     rf.assign_rule("HMC: Navigating the Toxic Maze", "WK/SF/BF/TJ")
     rf.assign_rule("HMC: Watch for Rolling Rocks", "WK")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -177,9 +177,9 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("THI: Make Wiggler Squirm", "GP | MOVELESS & DV")
     # Tick Tock Clock
     rf.assign_rule("TTC: Lower", "LG/TJ/SF/BF/WK")
-    rf.assign_rule("TTC: Upper", "CL | SF+WK")
-    rf.assign_rule("TTC: Top", "CL | SF+WK")
-    rf.assign_rule("TTC: Stomp on the Thwomp", "LG & TJ/SF/BF")
+    rf.assign_rule("TTC: Upper", "CL | MOVELESS & WK")
+    rf.assign_rule("TTC: Top", "CL | MOVELESS & WK/TJ)
+    rf.assign_rule("TTC: Stomp on the Thwomp", "TJ/SF/BF | MOVELESS")
     rf.assign_rule("TTC: Stop Time for Red Coins", "NAR | {TTC: Lower}")
     # Rainbow Ride
     rf.assign_rule("RR: Maze", "WK | LJ & SF/BF/TJ | MOVELESS & LG/TJ/KK")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -153,7 +153,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")
     rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
-    rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}}")
+    rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")
     rf.assign_rule("DDD: Through the Jet Stream", "MC | CAPLESS")
     rf.assign_rule("DDD: Collect the Caps...", "VC+MC | CAPLESS & VC")
     # Snowman's Land


### PR DESCRIPTION
## What is this fixing or adding?
Updating the logic of the move randomizer to fix bugs and add or remove options for stars to hopefully make strict a bit more streamlined and non-strict a bit more open.

## How was this tested?
Took feedback from discord channel and my own playtests to implement new rules. Made sure rules were valid through testing during my own seeds as well as in Usamune (SM64 practice rom).

Can't guarantee I hit everything that needed to be changed or adjusted but I tried to pour over all the stars the best I could. Definitely open to feedback or changes to any of the changes I am proposing.